### PR TITLE
Cleanup

### DIFF
--- a/TestGame/Entities/Entity.cs
+++ b/TestGame/Entities/Entity.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Xna.Framework;
+
+namespace TestGame.Entities
+{
+    public abstract class Entity : DrawableGameComponent
+    {
+        protected Entity(TestGame game) : base(game)
+        {
+        }
+
+        public new TestGame Game => (TestGame) base.Game;
+
+        public Sprite Sprite { get; protected set; }
+
+        public override void Draw(GameTime gameTime)
+        {
+            Sprite?.Draw(Game.SpriteBatch);
+
+            base.Draw(gameTime);
+        }
+    }
+}

--- a/TestGame/Entities/Player.cs
+++ b/TestGame/Entities/Player.cs
@@ -21,12 +21,14 @@ namespace TestGame.Entities
 
         public new TestGame Game => (TestGame) base.Game;
 
+        public float Velocity { get; set; } = 150.0f;
+
         protected override void LoadContent()
         {
             _fireEffect = Game.Content.Load<SoundEffect>("brother1");
             _fireEffectInstance = _fireEffect.CreateInstance();
             _sprite = Game.Content.Load<Texture2D>("hulk");
-            _size = new Point(_sprite.Width >> 1, _sprite.Height >> 1);
+            _size = new Point(_sprite.Width / 2, _sprite.Height / 2);
             UpdateBounds();
 
             base.LoadContent();
@@ -38,25 +40,25 @@ namespace TestGame.Entities
 
             if (Game.InputState.KeyDown(Keys.A) || Game.InputState.KeyDown(Keys.Left))
             {
-                _position.X -= deltaTime * 32.0f;
+                _position.X -= deltaTime * Velocity;
                 UpdateBounds();
             }
 
             if (Game.InputState.KeyDown(Keys.D) || Game.InputState.KeyDown(Keys.Right))
             {
-                _position.X += deltaTime * 32.0f;
+                _position.X += deltaTime * Velocity;
                 UpdateBounds();
             }
 
             if (Game.InputState.KeyDown(Keys.S) || Game.InputState.KeyDown(Keys.Down))
             {
-                _position.Y += deltaTime * 32.0f;
+                _position.Y += deltaTime * Velocity;
                 UpdateBounds();
             }
 
             if (Game.InputState.KeyDown(Keys.W) || Game.InputState.KeyDown(Keys.Up))
             {
-                _position.Y -= deltaTime * 32.0f;
+                _position.Y -= deltaTime * Velocity;
                 UpdateBounds();
             }
 
@@ -69,13 +71,13 @@ namespace TestGame.Entities
 
             if (Game.InputState.KeyPressed(Keys.Q))
             {
-                _size = new Point(_size.X << 1, _size.Y << 1);
+                _size = new Point(_size.X * 2, _size.Y * 2);
                 UpdateBounds();
             }
 
             if (Game.InputState.KeyPressed(Keys.E))
             {
-                _size = new Point(_size.X >> 1, _size.Y >> 1);
+                _size = new Point(_size.X / 2, _size.Y / 2);
                 UpdateBounds();
             }
 

--- a/TestGame/Entities/Player.cs
+++ b/TestGame/Entities/Player.cs
@@ -38,29 +38,28 @@ namespace TestGame.Entities
         {
             float deltaTime = (float) gameTime.ElapsedGameTime.TotalSeconds;
 
-            if (Game.InputState.KeyDown(Keys.A) || Game.InputState.KeyDown(Keys.Left))
+            if (Game.InputState.KeysDown(false, Keys.A, Keys.Left))
             {
                 Sprite.Position = new Vector2(Sprite.Position.X - deltaTime * Velocity, Sprite.Position.Y);
             }
 
-            if (Game.InputState.KeyDown(Keys.D) || Game.InputState.KeyDown(Keys.Right))
+            if (Game.InputState.KeysDown(false, Keys.D, Keys.Right))
             {
                 Sprite.Position = new Vector2(Sprite.Position.X + deltaTime * Velocity, Sprite.Position.Y);
             }
 
-            if (Game.InputState.KeyDown(Keys.S) || Game.InputState.KeyDown(Keys.Down))
+            if (Game.InputState.KeysDown(false, Keys.S, Keys.Down))
             {
                 Sprite.Position = new Vector2(Sprite.Position.X, Sprite.Position.Y + deltaTime * Velocity);
             }
 
-            if (Game.InputState.KeyDown(Keys.W) || Game.InputState.KeyDown(Keys.Up))
+            if (Game.InputState.KeysDown(false, Keys.W, Keys.Up))
             {
                 Sprite.Position = new Vector2(Sprite.Position.X, Sprite.Position.Y - deltaTime * Velocity);
             }
 
             if (Game.InputState.KeyPressed(Keys.Space) ||
-                Game.InputState.MousePressed(MouseButton.LeftButton) ||
-                Game.InputState.MousePressed(MouseButton.RightButton))
+                Game.InputState.MultiMousePressed(false, MouseButton.LeftButton, MouseButton.RightButton))
             {
                 _fireEffectInstance.Play();
             }

--- a/TestGame/Entities/Player.cs
+++ b/TestGame/Entities/Player.cs
@@ -6,19 +6,16 @@ using TestGame.Input;
 
 namespace TestGame.Entities
 {
-    public class Player : DrawableGameComponent
+    public class Player : Entity
     {
         private SoundEffect _fireEffect;
         private SoundEffectInstance _fireEffectInstance;
 
-        public Player(Game game) : base(game)
+        public Player(TestGame game) : base(game)
         {
         }
 
-        public new TestGame Game => (TestGame) base.Game;
-
         public float Velocity { get; set; } = 150.0f;
-        public Sprite Sprite { get; private set; }
 
         protected override void LoadContent()
         {
@@ -80,13 +77,6 @@ namespace TestGame.Entities
             }
 
             base.Update(gameTime);
-        }
-
-        public override void Draw(GameTime gameTime)
-        {
-            Sprite.Draw(Game.SpriteBatch);
-
-            base.Draw(gameTime);
         }
     }
 }

--- a/TestGame/Entities/Player.cs
+++ b/TestGame/Entities/Player.cs
@@ -10,10 +10,6 @@ namespace TestGame.Entities
     {
         private SoundEffect _fireEffect;
         private SoundEffectInstance _fireEffectInstance;
-        private Texture2D _sprite;
-        private Vector2 _position;
-        private Point _size;
-        private Rectangle _bounds;
 
         public Player(Game game) : base(game)
         {
@@ -22,14 +18,18 @@ namespace TestGame.Entities
         public new TestGame Game => (TestGame) base.Game;
 
         public float Velocity { get; set; } = 150.0f;
+        public Sprite Sprite { get; private set; }
 
         protected override void LoadContent()
         {
             _fireEffect = Game.Content.Load<SoundEffect>("brother1");
             _fireEffectInstance = _fireEffect.CreateInstance();
-            _sprite = Game.Content.Load<Texture2D>("hulk");
-            _size = new Point(_sprite.Width / 2, _sprite.Height / 2);
-            UpdateBounds();
+
+            Sprite = new Sprite
+            {
+                Texture = Game.Content.Load<Texture2D>("hulk"),
+                Size = new Vector2(256)
+            };
 
             base.LoadContent();
         }
@@ -40,26 +40,22 @@ namespace TestGame.Entities
 
             if (Game.InputState.KeyDown(Keys.A) || Game.InputState.KeyDown(Keys.Left))
             {
-                _position.X -= deltaTime * Velocity;
-                UpdateBounds();
+                Sprite.Position = new Vector2(Sprite.Position.X - deltaTime * Velocity, Sprite.Position.Y);
             }
 
             if (Game.InputState.KeyDown(Keys.D) || Game.InputState.KeyDown(Keys.Right))
             {
-                _position.X += deltaTime * Velocity;
-                UpdateBounds();
+                Sprite.Position = new Vector2(Sprite.Position.X + deltaTime * Velocity, Sprite.Position.Y);
             }
 
             if (Game.InputState.KeyDown(Keys.S) || Game.InputState.KeyDown(Keys.Down))
             {
-                _position.Y += deltaTime * Velocity;
-                UpdateBounds();
+                Sprite.Position = new Vector2(Sprite.Position.X, Sprite.Position.Y + deltaTime * Velocity);
             }
 
             if (Game.InputState.KeyDown(Keys.W) || Game.InputState.KeyDown(Keys.Up))
             {
-                _position.Y -= deltaTime * Velocity;
-                UpdateBounds();
+                Sprite.Position = new Vector2(Sprite.Position.X, Sprite.Position.Y - deltaTime * Velocity);
             }
 
             if (Game.InputState.KeyPressed(Keys.Space) ||
@@ -71,14 +67,12 @@ namespace TestGame.Entities
 
             if (Game.InputState.KeyPressed(Keys.Q))
             {
-                _size = new Point(_size.X * 2, _size.Y * 2);
-                UpdateBounds();
+                Sprite.Size = Sprite.Size * 2;
             }
 
             if (Game.InputState.KeyPressed(Keys.E))
             {
-                _size = new Point(_size.X / 2, _size.Y / 2);
-                UpdateBounds();
+                Sprite.Size = Sprite.Size / 2;
             }
 
             base.Update(gameTime);
@@ -86,14 +80,9 @@ namespace TestGame.Entities
 
         public override void Draw(GameTime gameTime)
         {
-            Game.SpriteBatch.Draw(_sprite, _bounds, Color.White);
+            Sprite.Draw(Game.SpriteBatch);
 
             base.Draw(gameTime);
-        }
-
-        private void UpdateBounds()
-        {
-            _bounds = new Rectangle(_position.ToPoint(), _size);
         }
     }
 }

--- a/TestGame/Entities/Player.cs
+++ b/TestGame/Entities/Player.cs
@@ -8,9 +8,6 @@ namespace TestGame.Entities
 {
     public class Player : DrawableGameComponent
     {
-        private readonly InputState _inputState;
-        private readonly SpriteBatch _spriteBatch;
-
         private SoundEffect _fireEffect;
         private SoundEffectInstance _fireEffectInstance;
         private Texture2D _sprite;
@@ -18,11 +15,11 @@ namespace TestGame.Entities
         private Point _size;
         private Rectangle _bounds;
 
-        public Player(Game game, InputState inputState, SpriteBatch spriteBatch) : base(game)
+        public Player(Game game) : base(game)
         {
-            _inputState = inputState;
-            _spriteBatch = spriteBatch;
         }
+
+        public new TestGame Game => (TestGame) base.Game;
 
         protected override void LoadContent()
         {
@@ -39,44 +36,44 @@ namespace TestGame.Entities
         {
             float deltaTime = (float) gameTime.ElapsedGameTime.TotalSeconds;
 
-            if (_inputState.KeyDown(Keys.A) || _inputState.KeyDown(Keys.Left))
+            if (Game.InputState.KeyDown(Keys.A) || Game.InputState.KeyDown(Keys.Left))
             {
                 _position.X -= deltaTime * 32.0f;
                 UpdateBounds();
             }
 
-            if (_inputState.KeyDown(Keys.D) || _inputState.KeyDown(Keys.Right))
+            if (Game.InputState.KeyDown(Keys.D) || Game.InputState.KeyDown(Keys.Right))
             {
                 _position.X += deltaTime * 32.0f;
                 UpdateBounds();
             }
 
-            if (_inputState.KeyDown(Keys.S) || _inputState.KeyDown(Keys.Down))
+            if (Game.InputState.KeyDown(Keys.S) || Game.InputState.KeyDown(Keys.Down))
             {
                 _position.Y += deltaTime * 32.0f;
                 UpdateBounds();
             }
 
-            if (_inputState.KeyDown(Keys.W) || _inputState.KeyDown(Keys.Up))
+            if (Game.InputState.KeyDown(Keys.W) || Game.InputState.KeyDown(Keys.Up))
             {
                 _position.Y -= deltaTime * 32.0f;
                 UpdateBounds();
             }
 
-            if (_inputState.KeyPressed(Keys.Space) ||
-                _inputState.MousePressed(MouseButton.LeftButton) ||
-                _inputState.MousePressed(MouseButton.RightButton))
+            if (Game.InputState.KeyPressed(Keys.Space) ||
+                Game.InputState.MousePressed(MouseButton.LeftButton) ||
+                Game.InputState.MousePressed(MouseButton.RightButton))
             {
                 _fireEffectInstance.Play();
             }
 
-            if (_inputState.KeyPressed(Keys.Q))
+            if (Game.InputState.KeyPressed(Keys.Q))
             {
                 _size = new Point(_size.X << 1, _size.Y << 1);
                 UpdateBounds();
             }
 
-            if (_inputState.KeyPressed(Keys.E))
+            if (Game.InputState.KeyPressed(Keys.E))
             {
                 _size = new Point(_size.X >> 1, _size.Y >> 1);
                 UpdateBounds();
@@ -87,7 +84,7 @@ namespace TestGame.Entities
 
         public override void Draw(GameTime gameTime)
         {
-            _spriteBatch.Draw(_sprite, _bounds, Color.White);
+            Game.SpriteBatch.Draw(_sprite, _bounds, Color.White);
 
             base.Draw(gameTime);
         }

--- a/TestGame/Entities/Player.cs
+++ b/TestGame/Entities/Player.cs
@@ -40,22 +40,22 @@ namespace TestGame.Entities
 
             if (Game.InputState.KeysDown(false, Keys.A, Keys.Left))
             {
-                Sprite.Position = new Vector2(Sprite.Position.X - deltaTime * Velocity, Sprite.Position.Y);
+                Sprite.Position = Sprite.Position.SubX(deltaTime * Velocity);
             }
 
             if (Game.InputState.KeysDown(false, Keys.D, Keys.Right))
             {
-                Sprite.Position = new Vector2(Sprite.Position.X + deltaTime * Velocity, Sprite.Position.Y);
+                Sprite.Position = Sprite.Position.AddX(deltaTime * Velocity);
             }
 
             if (Game.InputState.KeysDown(false, Keys.S, Keys.Down))
             {
-                Sprite.Position = new Vector2(Sprite.Position.X, Sprite.Position.Y + deltaTime * Velocity);
+                Sprite.Position = Sprite.Position.AddY(deltaTime * Velocity);
             }
 
             if (Game.InputState.KeysDown(false, Keys.W, Keys.Up))
             {
-                Sprite.Position = new Vector2(Sprite.Position.X, Sprite.Position.Y - deltaTime * Velocity);
+                Sprite.Position = Sprite.Position.SubY(deltaTime * Velocity);
             }
 
             if (Game.InputState.KeyPressed(Keys.Space) ||

--- a/TestGame/Entities/Player.cs
+++ b/TestGame/Entities/Player.cs
@@ -74,6 +74,11 @@ namespace TestGame.Entities
                 Sprite.Size = Sprite.Size / 2;
             }
 
+            if (Game.InputState.KeyDown(Keys.Z))
+            {
+                Sprite.Rotation += deltaTime;
+            }
+
             base.Update(gameTime);
         }
 

--- a/TestGame/Input/InputState.cs
+++ b/TestGame/Input/InputState.cs
@@ -9,6 +9,8 @@ namespace TestGame.Input
     /// </summary>
     public class InputState
     {
+        #region Constructor
+
         public InputState()
         {
             CurrentKeyboardState = Keyboard.GetState();
@@ -38,6 +40,10 @@ namespace TestGame.Input
                 gamePadState4
             };
         }
+
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// The keyboard state this frame.
@@ -69,6 +75,8 @@ namespace TestGame.Input
         /// </summary>
         public GamePadState[] PreviousGamePadStates { get; }
 
+        #endregion
+
 
         /// <summary>
         /// Update the input state for the current frame.
@@ -88,6 +96,8 @@ namespace TestGame.Input
                 CurrentGamePadStates[i] = GamePad.GetState(i);
             }
         }
+
+        #region Single State Queries
 
         /// <summary>
         /// Gets whether given key is currently being pressed.
@@ -183,6 +193,54 @@ namespace TestGame.Input
             return CurrentGamePadStates[index].IsButtonDown(button) &&
                    PreviousGamePadStates[index].IsButtonUp(button);
         }
+
+        #endregion
+
+        #region Multiple State Queries
+
+        /// <summary>
+        /// Gets whether the given keys are currently being pressed.
+        /// </summary>
+        /// <param name="all">Return true for all keys vs any key</param>
+        /// <param name="keys">The keys to query</param>
+        /// <returns>If keys are pressed</returns>
+        public bool KeysDown(bool all, params Keys[] keys)
+        {
+            bool result = all;
+
+            foreach (var key in keys)
+            {
+                if (all)
+                    result &= KeyDown(key);
+                else
+                    result |= KeyDown(key);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets whether the given buttons are being pressed this frame.
+        /// </summary>
+        /// <param name="all">Return true for all buttons vs any button</param>
+        /// <param name="buttons">The buttons to query</param>
+        /// <returns>If buttons are pressed</returns>
+        public bool MultiMousePressed(bool all, params MouseButton[] buttons)
+        {
+            bool result = all;
+
+            foreach (var button in buttons)
+            {
+                if (all)
+                    result &= MousePressed(button);
+                else
+                    result |= MousePressed(button);
+            }
+
+            return result;
+        }
+
+        #endregion
 
         private ButtonState MouseButtonToState(MouseButton button, bool useCurrent = true)
         {

--- a/TestGame/Sprite.cs
+++ b/TestGame/Sprite.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace TestGame
+{
+    public class Sprite
+    {
+        private Vector2 _position;
+        private Vector2 _size;
+
+        public Texture2D Texture { get; set; }
+
+        public float Rotation { get; set; }
+
+        public Vector2 Position
+        {
+            get => _position;
+            set
+            {
+                _position = value;
+                Bounds = new Rectangle(_position.ToPoint(), _size.ToPoint());
+            }
+        }
+
+        public Vector2 Size
+        {
+            get => _size;
+            set
+            {
+                _size = value;
+                Bounds = new Rectangle(_position.ToPoint(), _size.ToPoint());
+            }
+        }
+
+        public Rectangle Bounds { get; private set; }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            spriteBatch.Draw(Texture, Bounds, null, Color.White, Rotation, Vector2.Zero, SpriteEffects.None, 0);
+        }
+    }
+}

--- a/TestGame/Sprite.cs
+++ b/TestGame/Sprite.cs
@@ -5,12 +5,23 @@ namespace TestGame
 {
     public class Sprite
     {
+        private Texture2D _texture;
         private Vector2 _position;
         private Vector2 _size;
 
-        public Texture2D Texture { get; set; }
+        public Texture2D Texture
+        {
+            get => _texture;
+            set
+            {
+                _texture = value;
+                Origin = new Vector2(_texture.Width / 2.0f, _texture.Height / 2.0f);
+            }
+        }
 
         public float Rotation { get; set; }
+
+        public Vector2 Origin { get; set; }
 
         public Vector2 Position
         {
@@ -18,7 +29,9 @@ namespace TestGame
             set
             {
                 _position = value;
-                Bounds = new Rectangle(_position.ToPoint(), _size.ToPoint());
+
+                var offset = Texture != null ? Origin / 2 : Vector2.Zero;
+                Bounds = new Rectangle((_position + offset).ToPoint(), _size.ToPoint());
             }
         }
 
@@ -28,7 +41,9 @@ namespace TestGame
             set
             {
                 _size = value;
-                Bounds = new Rectangle(_position.ToPoint(), _size.ToPoint());
+
+                var offset = Texture != null ? Origin / 2 : Vector2.Zero;
+                Bounds = new Rectangle((_position + offset).ToPoint(), _size.ToPoint());
             }
         }
 
@@ -36,7 +51,7 @@ namespace TestGame
 
         public void Draw(SpriteBatch spriteBatch)
         {
-            spriteBatch.Draw(Texture, Bounds, null, Color.White, Rotation, Vector2.Zero, SpriteEffects.None, 0);
+            spriteBatch.Draw(Texture, Bounds, null, Color.White, Rotation, Origin, SpriteEffects.None, 0);
         }
     }
 }

--- a/TestGame/TestGame.cs
+++ b/TestGame/TestGame.cs
@@ -13,8 +13,6 @@ namespace TestGame
     public class TestGame : Game
     {
         private readonly GraphicsDeviceManager _graphics;
-        private SpriteBatch _spriteBatch;
-        private InputState _inputState;
 
         private Texture2D _flagTexture;
         private Song _song;
@@ -24,15 +22,18 @@ namespace TestGame
             _graphics = new GraphicsDeviceManager(this);
         }
 
+        public SpriteBatch SpriteBatch { get; private set; }
+        public InputState InputState { get; private set; }
+
         protected override void Initialize()
         {
             Content.RootDirectory = "Content";
             IsMouseVisible = true;
 
-            _spriteBatch = new SpriteBatch(GraphicsDevice);
-            _inputState = new InputState();
+            SpriteBatch = new SpriteBatch(GraphicsDevice);
+            InputState = new InputState();
 
-            Components.Add(new Player(this, _inputState, _spriteBatch));
+            Components.Add(new Player(this));
 
             base.Initialize();
         }
@@ -49,16 +50,16 @@ namespace TestGame
 
         protected override void Update(GameTime gameTime)
         {
-            _inputState.Update();
+            InputState.Update();
 
             // Exit on escape or back
-            if (_inputState.KeyDown(Keys.Escape) || _inputState.GamePadButtonDown(0, Buttons.Back))
+            if (InputState.KeyDown(Keys.Escape) || InputState.GamePadButtonDown(0, Buttons.Back))
             {
                 Exit();
             }
 
             // Change window mode only on key press, not hold
-            if (_inputState.KeyPressed(Keys.F11))
+            if (InputState.KeyPressed(Keys.F11))
             {
                 if (!Window.IsBorderless)
                 {
@@ -88,13 +89,13 @@ namespace TestGame
         {
             GraphicsDevice.Clear(Color.CornflowerBlue);
 
-            _spriteBatch.Begin();
+            SpriteBatch.Begin();
 
-            _spriteBatch.Draw(_flagTexture, GraphicsDevice.Viewport.Bounds, Color.White);
+            SpriteBatch.Draw(_flagTexture, GraphicsDevice.Viewport.Bounds, Color.White);
 
             base.Draw(gameTime);
 
-            _spriteBatch.End();
+            SpriteBatch.End();
         }
     }
 }

--- a/TestGame/TestGame.cs
+++ b/TestGame/TestGame.cs
@@ -69,17 +69,16 @@ namespace TestGame
 
                     // Set position to top left corner, avoids offset by taskbars
                     Window.Position = new Point(0, 0);
-                    Window.IsBorderless = true;
-                    _graphics.ApplyChanges();
                 }
                 else
                 {
                     // Default window size
                     _graphics.PreferredBackBufferWidth = 800;
                     _graphics.PreferredBackBufferHeight = 480;
-                    Window.IsBorderless = false;
-                    _graphics.ApplyChanges();
                 }
+
+                Window.IsBorderless = !Window.IsBorderless;
+                _graphics.ApplyChanges();
             }
 
             base.Update(gameTime);

--- a/TestGame/TestGame.csproj
+++ b/TestGame/TestGame.csproj
@@ -48,6 +48,7 @@
     <Compile Include="TestGame.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Vector2Extensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework">

--- a/TestGame/TestGame.csproj
+++ b/TestGame/TestGame.csproj
@@ -41,6 +41,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Entities\Entity.cs" />
     <Compile Include="Entities\Player.cs" />
     <Compile Include="Input\InputState.cs" />
     <Compile Include="Input\MouseButton.cs" />

--- a/TestGame/TestGame.csproj
+++ b/TestGame/TestGame.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Entities\Player.cs" />
     <Compile Include="Input\InputState.cs" />
     <Compile Include="Input\MouseButton.cs" />
+    <Compile Include="Sprite.cs" />
     <Compile Include="TestGame.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/TestGame/Vector2Extensions.cs
+++ b/TestGame/Vector2Extensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+
+namespace TestGame
+{
+    public static class Vector2Extensions
+    {
+        public static Vector2 AddX(this Vector2 value, float add)
+        {
+            return new Vector2(value.X + add, value.Y);
+        }
+
+        public static Vector2 SubX(this Vector2 value, float sub)
+        {
+            return new Vector2(value.X - sub, value.Y);
+        }
+
+        public static Vector2 AddY(this Vector2 value, float add)
+        {
+            return new Vector2(value.X, value.Y + add);
+        }
+
+        public static Vector2 SubY(this Vector2 value, float sub)
+        {
+            return new Vector2(value.X, value.Y - sub);
+        }
+    }
+}

--- a/TestGame/Vector2Extensions.cs
+++ b/TestGame/Vector2Extensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 
 namespace TestGame
 {


### PR DESCRIPTION
* Create base class `Entity` for drawable game components
* Create utility class `Sprite` to hold rendering info for drawable objects
* Reference `InputState` and `SpriteBatch` directly on passed `Game` object rather than through constructor reference
* Extend `InputState` to query multiple buttons at once (Didn't add every case, just the ones I'm using)
* Add Vector2 extension methods to make is slightly less annoying
* Figure out rotating sprites about their origin